### PR TITLE
Fix render deployment csp error

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -105,7 +105,14 @@ services:
         value: nosniff
       - path: /*
         name: Content-Security-Policy
-        value: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cesium.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cesium.com; img-src 'self' data: https: blob:; connect-src 'self' https://api.cesium.com https://assets.ion.cesium.com wss: ws:; worker-src 'self' blob:; font-src 'self' https:;
+        value: >
+          default-src 'self';
+          script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cesium.com https://cdn.jsdelivr.net;
+          style-src 'self' 'unsafe-inline' https://cesium.com;
+          img-src 'self' data: https: blob:;
+          connect-src 'self' https://api.cesium.com https://assets.ion.cesium.com wss: ws:;
+          worker-src 'self' blob:;
+          font-src 'self' https:;
     routes:
       - type: redirect
         source: /*


### PR DESCRIPTION
Reformat `Content-Security-Policy` header value in `render.yaml` to fix a deployment error.

The previous single-line format of the long CSP string caused a parsing error during deployment on Render. This change uses YAML's folded block scalar (`>`) to properly format the multi-line string, ensuring correct parsing while maintaining the original CSP value.

---
<a href="https://cursor.com/background-agent?bcId=bc-3b0be423-df60-43d8-9ecc-5b89561ec6f3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3b0be423-df60-43d8-9ecc-5b89561ec6f3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

