### PR TITLE
Fix content security policy deployment error

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -105,7 +105,7 @@ services:
         value: nosniff
       - path: /*
         name: Content-Security-Policy
-        value: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cesium.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cesium.com; img-src 'self' data: https: blob:; connect-src 'self' https://api.cesium.com https://assets.ion.cesium.com wss: ws:; worker-src 'self' blob:; font-src 'self' https:;
+        value: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cesium.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cesium.com; img-src 'self' data: https: blob:; connect-src 'self' https://api.cesium.com https://assets.ion.cesium.com wss: ws:; worker-src 'self' blob:; font-src 'self' https:;"
     routes:
       - type: redirect
         source: /*


### PR DESCRIPTION
Quote Content-Security-Policy value in `render.yaml` to resolve YAML parsing error during Render deployment.

---
<a href="https://cursor.com/background-agent?bcId=bc-4e5423b6-3739-4681-b664-3df398b7a3b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4e5423b6-3739-4681-b664-3df398b7a3b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

