### PR TITLE
Resolve duplicate github ci/cd naming conflicts

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,4 +1,4 @@
-name: Satellite Tracking Platform CI/CD
+name: CI/CD Pipeline
 
 on:
   push:


### PR DESCRIPTION
Rename GitHub Actions workflow to resolve repeated status check messages.

---
<a href="https://cursor.com/background-agent?bcId=bc-b7ecb409-c3ee-438e-8c60-506f120602e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b7ecb409-c3ee-438e-8c60-506f120602e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

